### PR TITLE
Add netlb index from sources/HAProxy

### DIFF
--- a/docs/gettingstarted/index.md
+++ b/docs/gettingstarted/index.md
@@ -44,6 +44,7 @@ using the SC4S defaults. SC4S can be easily customized to use different indexes 
 * netdns
 * netfw
 * netids
+* netlb
 * netops
 * netwaf
 * netproxy


### PR DESCRIPTION
The netlb index is referenced in sources/HAProxy/#index-configuration but is not on the main getting started page. As such I did not create it and haven't been getting my HAProxy logs.